### PR TITLE
Add PDN_sleep and PDN_wakeup

### DIFF
--- a/include/arm11/drivers/pdn.h
+++ b/include/arm11/drivers/pdn.h
@@ -161,6 +161,8 @@ void PDN_core123Init(void);
 void PDN_setSocmode(PdnSocmode socmode);
 void PDN_poweroffCore23(void);
 void PDN_controlGpu(const bool enableClk, const bool resetPsc, const bool resetOther);
+void PDN_sleep(void);
+void PDN_wakeup(void);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/kernel/include/internal/config.h
+++ b/kernel/include/internal/config.h
@@ -25,7 +25,7 @@
  * Maximum number of objects we can create (Slabheap).
 */
 #define MAX_TASKS        (3) // Including main and idle task.
-#define MAX_EVENTS       (10)
+#define MAX_EVENTS       (11)
 #define MAX_MUTEXES      (3)
 #define MAX_SEMAPHORES   (0)
 #define MAX_TIMERS       (0)

--- a/source/arm11/drivers/gfx.c
+++ b/source/arm11/drivers/gfx.c
@@ -550,8 +550,47 @@ void GX_processCommandList(const u32 size, const u32 *const cmdList)
 	gx->p3d[GPUREG_CMDBUF_JUMP0] = 1;
 }
 
+void GFX_enterLowPowerState(void)
+{
+	GFX_setForceBlack(true, true);
+	const GfxState *const state = &g_gfxState;
+	LCD_deinit(state->mcuLcdState);
+	stopDisplayControllersSafe();
+
+	for(u8 i = 0; i < 6; i++)
+	{
+		unbindInterruptEvent(IRQ_PSC0 + i);
+	}
+
+	PDN_controlGpu(false, false, false);
+	PDN_sleep();
+}
+
+void GFX_returnFromLowPowerState(void)
+{
+	PDN_wakeup();
+	PDN_controlGpu(true, false, false);
+
+	for(u8 i = 0; i < 6; i++)
+	{
+		bindInterruptToEvent(g_gfxState.events[i], IRQ_PSC0 + i, 14);
+	}
+
+	displayControllerInit(GFX_TOP_2D);
+	const GfxState *const state = &g_gfxState;
+
+	LCD_init(state->mcuLcdState<<1, state->lcdLum);
+	GFX_setForceBlack(false, false);
+
+	GFX_waitForVBlank0();
+	GFX_waitForVBlank0();
+}
+
+
 void GFX_sleep(void)
 {
+	GFX_setForceBlack(true, true);
+
 	const GfxState *const state = &g_gfxState;
 	LCD_deinit(state->mcuLcdState);
 
@@ -567,6 +606,11 @@ void GFX_sleep(void)
 	// Stop display controllers.
 	stopDisplayControllersSafe();
 
+	for(u8 i = 0; i < 6; i++)
+	{
+		unbindInterruptEvent(IRQ_PSC0 + i);
+	}
+
 	// Wait for at least 1 horizontal line. 40 µs in this case.
 	// 16713.680875044929009032708 / 413 = 40.468960956525251837852 µs.
 	// TODO: 40 µs may not be enough in legacy mode?
@@ -581,12 +625,19 @@ void GFX_sleep(void)
 
 	// Stop clock.
 	PDN_controlGpu(false, false, false);
+	PDN_sleep();
 }
 
 void GFX_sleepAwake(void)
 {
+	PDN_wakeup();
 	// Resume clock and reset PSC.
 	PDN_controlGpu(true, true, false);
+
+	for(u8 i = 0; i < 6; i++)
+	{
+		bindInterruptToEvent(g_gfxState.events[i], IRQ_PSC0 + i, 14);
+	}
 
 	// Restore PSC settings.
 	GxRegs *const gx = getGxRegs();
@@ -605,23 +656,14 @@ void GFX_sleepAwake(void)
 	// TODO: Do we need the PPF hardware bug workaround here too?
 	//       Since PPF is not being reset i don't think so?
 
-	// Initialize display controllers.
-	// gsp does completely reinitialize both display controllers here.
-	// Since both PDCs are not reset in sleep mode this is not strictly necessary.
-	// Warning: If we decide to change this to a full reinit restore the mode!
-	const GfxState *const state = &g_gfxState;
-	gx->pdc0.swap = state->swap;    // Bit 1 is not writable.
-	gx->pdc1.swap = state->swap>>1;
-	gx->pdc0.cnt  = PDC_CNT_OUT_EN | GFX_PDC0_IRQS | PDC_CNT_EN;
-	gx->pdc1.cnt  = PDC_CNT_OUT_EN | GFX_PDC1_IRQS | PDC_CNT_EN;
+	displayControllerInit(GFX_TOP_2D);
 
 	// TODO: Enable 3D LED if needed.
 
 	// Power on LCDs and backlights.
+	const GfxState *const state = &g_gfxState;
 	LCD_init(state->mcuLcdState<<1, state->lcdLum);
 
-	// Active backlight and luminance stuff.
-	// TODO
 
 	// Not from gsp. Wait for VRAM clear finish.
 	GFX_waitForPSC0();
@@ -629,6 +671,9 @@ void GFX_sleepAwake(void)
 
 	// Enable frame buffer output.
 	GFX_setForceBlack(false, false);
+
+	GFX_waitForVBlank0();
+	GFX_waitForVBlank0();
 }
 
 bool GFX_setupExceptionFrameBuffer(void)

--- a/source/arm11/drivers/pdn.c
+++ b/source/arm11/drivers/pdn.c
@@ -25,6 +25,7 @@
 #include "arm11/start.h"
 #include "util.h"
 #include "arm11/drivers/scu.h"
+#include "kevent.h"
 
 
 //#define CORE123_INIT (1)
@@ -212,4 +213,25 @@ void PDN_controlGpu(const bool enableClk, const bool resetPsc, const bool resetO
 		wait_cycles(12); // 4x the needed cycles in case we are in LGR2 mode.
 		pdn->gpu_cnt = reg | PDN_GPU_CNT_NORST_ALL;
 	}
+}
+
+void PDN_sleep(void)
+{
+	getPdnRegs()->wake_enable = PDN_WAKE_SHELL_OPENED;
+	getPdnRegs()->cnt |= PDN_CNT_SLEEP;
+}
+
+void PDN_wakeup(void)
+{
+	static KHandle pdnWakeEvent;
+	if (!pdnWakeEvent)
+	{
+		pdnWakeEvent = createEvent(true);
+	}
+
+	bindInterruptToEvent(pdnWakeEvent, IRQ_PDN, 14);
+	waitForEvent(pdnWakeEvent);
+	getPdnRegs()->wake_enable = 0;
+	getPdnRegs()->wake_reason = PDN_WAKE_SHELL_OPENED;
+	unbindInterruptEvent(IRQ_PDN);
 }


### PR DESCRIPTION
Supersedes #1 

This change is mostly to support open_agb_firm sleep functionality.

Waking up from sleep is achieved by binding IRQ_PDN to a handler and disabling wake_enable and confirming by writing to wake_reason.